### PR TITLE
undo SYS_llseek patch, use __llseek throughout

### DIFF
--- a/arch/riscv32/bits/syscall.h.in
+++ b/arch/riscv32/bits/syscall.h.in
@@ -60,7 +60,7 @@
 #define __NR_pipe2 59
 #define __NR_quotactl 60
 #define __NR_getdents64 61
-#define __NR_llseek 62
+#define __NR__llseek 62
 #define __NR_read 63
 #define __NR_write 64
 #define __NR_readv 65

--- a/src/stdio/__stdio_seek.c
+++ b/src/stdio/__stdio_seek.c
@@ -1,13 +1,9 @@
 #include "stdio_impl.h"
 
-#if defined(SYS__llseek) && !defined(SYS_llseek)
-#define SYS_llseek SYS__llseek
-#endif
-
 off_t __stdio_seek(FILE *f, off_t off, int whence)
 {
 	off_t ret;
-#ifdef SYS_llseek
+#ifdef SYS__llseek
 	if (syscall(SYS_llseek, f->fd, off>>32, off, &ret, whence)<0)
 		ret = -1;
 #else

--- a/src/unistd/lseek.c
+++ b/src/unistd/lseek.c
@@ -2,13 +2,9 @@
 #include "syscall.h"
 #include "libc.h"
 
-#if defined(SYS__llseek) && !defined(SYS_llseek)
-#define SYS_llseek SYS__llseek
-#endif
-
 off_t lseek(int fd, off_t offset, int whence)
 {
-#ifdef SYS_llseek
+#ifdef SYS__llseek
 	off_t result;
 	return syscall(SYS_llseek, fd, offset>>32, offset, &result, whence) ? -1 : result;
 #else


### PR DESCRIPTION
Sorry for the previous patch, did not check it well. It should have been a one-line change.
There's no real need to keep SYS_\* symbols in sync with the kernel headers.
All other 32-bit targets in musl use SYS__llseek with double underscores.
